### PR TITLE
Update autoindex.html to preview .html files

### DIFF
--- a/autoindex.html
+++ b/autoindex.html
@@ -37,6 +37,7 @@
 	head.add('meta').attr('charset', 'utf-8')
 	head.add('meta').attr('name', 'viewport').attr('content', 'width=device-width,initial-scale=1')
 
+	if (document.title && !document.title.startsWith('Index of /')) return
 	if (!document.title) {
 		document.write(["<div class=\"container\">",
 		"<h3>nginx.conf</h3>",


### PR DESCRIPTION
When we preview a html file that nginx served, itself might contain a "title" element which will mislead the appended scripts in "autoindex.html" to render a directory list page. This method uses the title pattern "Index of /" to prevent it happen.